### PR TITLE
Fix wrong string compare and deprecated numpy array value extraction …

### DIFF
--- a/examples/mpi4py/example3/example3.py
+++ b/examples/mpi4py/example3/example3.py
@@ -40,12 +40,12 @@ def generate_initial_state(method='random', file_name=None, num_particles=None, 
     """
 
 
-    if method is 'random':
+    if method == 'random':
 
         np.random.seed(seed=1)
         coordinates = (0.5 - np.random.rand(num_particles, 3)) * box_length
 
-    elif method is 'file':
+    elif method == 'file':
 
         coordinates = np.loadtxt(file_name, skiprows=2, usecols=(1,2,3))
 
@@ -320,7 +320,7 @@ def main():
 
         total_energy = (total_pair_energy + tail_correction) / num_particles
 
-        energy_array[i_step] = total_energy
+        energy_array[i_step] = total_energy.item()
 
         if np.mod(i_step + 1, freq) == 0:
             if my_rank == 0:

--- a/examples/mpi4py/example3/final/example3.py
+++ b/examples/mpi4py/example3/final/example3.py
@@ -40,12 +40,12 @@ def generate_initial_state(method='random', file_name=None, num_particles=None, 
     """
 
 
-    if method is 'random':
+    if method == 'random':
 
         np.random.seed(seed=1)
         coordinates = (0.5 - np.random.rand(num_particles, 3)) * box_length
 
-    elif method is 'file':
+    elif method == 'file':
 
         coordinates = np.loadtxt(file_name, skiprows=2, usecols=(1,2,3))
 
@@ -342,7 +342,7 @@ def main():
 
             total_energy = (total_pair_energy + tail_correction) / num_particles
 
-            energy_array[i_step] = total_energy
+            energy_array[i_step] = total_energy.item()
 
             if np.mod(i_step + 1, freq) == 0:
 


### PR DESCRIPTION
Fix wrong string compare and deprecated numpy array value extraction, namely these warnings:
```
mpirun -np 4 python3 example3.py
/home/max/repos/parallel-programming/examples/mpi4py/example3/final/example3.py:43: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if method is 'random':
/home/max/repos/parallel-programming/examples/mpi4py/example3/final/example3.py:48: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif method is 'file':
...
/home/max/repos/parallel-programming/examples/mpi4py/example3/final/example3.py:345: DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
  energy_array[i_step] = total_energy
```